### PR TITLE
Add JiangSu protest afican immigrants 2020

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,4 +9,4 @@ pages:
     - .
     expire_in: 1 day
   only:
-  - gh-pages
+  - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,4 +9,4 @@ pages:
     - .
     expire_in: 1 day
   only:
-  - master
+  - gh-pages

--- a/README.adoc
+++ b/README.adoc
@@ -10,14 +10,14 @@
 :toclevels: 6
 :toc-title:
 
-https://cirosantilli.com/china-dictatorship[cirosantilli.com] | https://cirosantilli.gitlab.io/china-dictatorshi[gitlab.io] | https://github.com/cirosantilli/china-dictatorship[GitHub project] | https://github.com/cirosantilli/china-dictatorship/archive/gh-pages.zip[GitHub HTML download]
+https://cirosantilli.com/china-dictatorship[cirosantilli.com] https://cirosantilli.gitlab.io/china-dictatorship[gitlab.io] | https://github.com/cirosantilli/china-dictatorship[GitHub project] | https://github.com/cirosantilli/china-dictatorship/archive/gh-pages.zip[GitHub HTML download]
 
 Chinese "Communist" <<dictatorship,"Dictatorship">> "facts". 中国《共产主义》<<dictatorship,《独裁统治》>>的《事实》。<<faq,FAQ>>, <<news,news compilation>> and <<restaurants,restaurant>> and <<music,music>> recommendations. <<faq,常见问答集>>，<<news,新闻集>>和<<restaurants,饭店>>和<<music,音乐>>建议。<<xi-abolishes-term-limits-2018-03,Heil Xi 卐>>. <<xi-abolishes-term-limits-2018-03,习万岁>>。
 
 This README is too large and so https://github.com/isaacs/github/issues/1610[GitHub cuts it up] on https://github.com/cirosantilli/china-dictatorship[github.com]. You can view it fully at either:
 
 * https://cirosantilli.com/china-dictatorship[]. Canonical, https://zh.greatfire.org/https/cirosantilli.com[blocked in China since 2020] according to <<greatfire>>.
-* https://cirosantilli.gitlab.io/china-dictatorshi[], Let's see how good is the <<gfw>> at blocking subdomains.
+* https://cirosantilli.gitlab.io/china-dictatorship[], Let's see how good is the <<gfw>> at blocking subdomains.
 
 or by downloading it locally as shown at: <<mirrors>>.
 


### PR DESCRIPTION
It's a good & obviously example of ccp dictatorship.The gov trans 500k afican by no any democracy processes.This is not over yet. They gave these immigrants super-national treatments,also,by no democracy processes by people (mention: in cn constitution : anyone can never ever get super-national treatments)They gave it to the immigrants,they don't even think about people.these treatments are about: one immigrant can get a Chinese student girl study with it(this makes every students angry very),can get work primarilier by Chinese citizens (this makes every workers angry very) And,if these immigrants crimes,they can hardly go to jail.(this makes every Chinese angry very).So ,many cn are trolling the ccp are dictator(it is infact).the cn gov hosted a vote to choice should leave the immigrants or fuck them off after the gov already trans 500k immigrants in china. every citizens disagree to leave them in china,some wumaos are agree"the ccp have there own clever dicisions to make china better in the world that normal people can never understand".but one thing makes these wumaos angry too:one immigrant rape a 17 years old girl in Nanjing but only get in jail for 15days! Oh god,the citizens go whoring will get mouths in jail and if rape,maybe 20years+. The final result of voting is 80%disagree and 20%disagree(some are wumaos some are fake users by ccp),then,to continue the dictatorship,ccp "made" the result that the agree >disagree (if you choose disgree it's actually agree,agree is still agree). After, Nanjing students went to streets to protest,a number of got in jail surely.but the ccp afraid it's control get over,so free the protestion students in Nanjing,and deleted all news,qq,wechat information about it,at least in china.