### PR TITLE
Switch to jsDelivr

### DIFF
--- a/action.js
+++ b/action.js
@@ -40,7 +40,7 @@ for await (const line of rl) {
 images = getRandom(Array.from(images), 30);
 full_images = []
 for (const image of images) {
-  const url = `https://raw.githubusercontent.com/cirosantilli/china-dictatorship-media/master/${image}`;
+  const url = `https://cdn.jsdelivr.net/gh/cirosantilli/china-dictatorship-media/${image}`;
   full_images.push(image.replace(/[_.]/g, ' '));
   full_images.push(`<img src="${url}" width="600">`);
 }

--- a/images.js
+++ b/images.js
@@ -42,7 +42,7 @@ if (process.argv.length > 2) {
 }
 full_images = []
 for (const image of images) {
-  const url = `https://raw.githubusercontent.com/cirosantilli/china-dictatorship-media/master/${image}`;
+  const url = `https://cdn.jsdelivr.net/gh/cirosantilli/china-dictatorship-media/${image}`;
   full_images.push(image.replace(/[_.]/g, ' '));
   full_images.push(`<img src="${url}" width="600">`);
 }


### PR DESCRIPTION
* https://raw.githubusercontent.com/cirosantilli/china-dictatorship-media/master/Snowden.jpg
* https://cdn.jsdelivr.net/gh/cirosantilli/china-dictatorship-media/Snowden.jpg

@cirosantilli The raw domain is hijacked to 0.0.0.0 in most provinces; replace them to jsDelivr to produce more collateral damage.